### PR TITLE
Update tough-cookie node version

### DIFF
--- a/Airports/Airports-APIKey/package-lock.json
+++ b/Airports/Airports-APIKey/package-lock.json
@@ -1284,7 +1284,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~5.1.2",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
@@ -1555,8 +1555,8 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dependencies": {
         "psl": "^1.1.28",

--- a/Airports/Airports-OAuth/package-lock.json
+++ b/Airports/Airports-OAuth/package-lock.json
@@ -1343,7 +1343,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~5.1.2",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
@@ -1600,8 +1600,8 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dependencies": {
         "psl": "^1.1.28",


### PR DESCRIPTION
Update tough-cookie node version to fix (CVE-2023-26136)